### PR TITLE
feat: add Tavily web search as configurable parallel provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.18.1",
+        "@tavily/core": "^0.6.1",
         "async": "^3.2.6",
         "axios": "^1.12.2",
         "cheerio": "^1.1.2",
@@ -65,6 +66,16 @@
         }
       }
     },
+    "node_modules/@tavily/core": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@tavily/core/-/core-0.6.4.tgz",
+      "integrity": "sha512-PppC0p2SwkoImLiYFT/uqDyWKPivpVsIM16HUf1Apmtbqg1YhI7Yg5Hq6eYSojC6COVCGXE4CotBnWqUmrai+A==",
+      "dependencies": {
+        "axios": "^1.7.7",
+        "https-proxy-agent": "^7.0.6",
+        "js-tiktoken": "^1.0.14"
+      }
+    },
     "node_modules/@types/node": {
       "version": "24.5.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
@@ -86,6 +97,14 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -141,6 +160,25 @@
         "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/body-parser": {
       "version": "2.2.1",
@@ -601,7 +639,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -913,6 +950,18 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -959,6 +1008,14 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-tiktoken": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
+      "integrity": "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==",
+      "dependencies": {
+        "base64-js": "^1.5.1"
       }
     },
     "node_modules/jsdoctypeparser": {
@@ -1585,7 +1642,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.18.1",
+    "@tavily/core": "^0.6.1",
     "async": "^3.2.6",
     "axios": "^1.12.2",
     "cheerio": "^1.1.2",

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,1 +1,7 @@
 runtime: "typescript"
+configSchema:
+  type: object
+  properties:
+    TAVILY_API_KEY:
+      type: string
+      description: "Optional Tavily API key. When set, enables the TavilyWebSearch tool."

--- a/src/index.ts
+++ b/src/index.ts
@@ -427,7 +427,13 @@ server.registerTool(
 );
 
 // Conditionally register Tavily search tool when API key is available
-const tavilyApiKey = (config.TAVILY_API_KEY as string) || process.env.TAVILY_API_KEY;
+const tavilyApiKeyCandidates = [
+  config.TAVILY_API_KEY,
+  process.env.TAVILY_API_KEY,
+];
+const tavilyApiKey = tavilyApiKeyCandidates.find(
+  (value): value is string => typeof value === "string" && value.trim().length > 0,
+)?.trim();
 if (tavilyApiKey) {
   const tavilyClient = tavily({ apiKey: tavilyApiKey });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { v4 as uuidv4 } from "uuid";
 import * as fs from "fs/promises";
 import * as path from "path";
 import { z } from "zod";
+import { tavily } from "@tavily/core";
 
 // Define the Context interface if not already defined
 interface Context {
@@ -424,6 +425,78 @@ server.registerTool(
     };
   },
 );
+
+// Conditionally register Tavily search tool when API key is available
+const tavilyApiKey = (config.TAVILY_API_KEY as string) || process.env.TAVILY_API_KEY;
+if (tavilyApiKey) {
+  const tavilyClient = tavily({ apiKey: tavilyApiKey });
+
+  server.registerTool(
+    "TavilyWebSearch",
+    {
+      description:
+        "Initiates a web search query using the Tavily search API and returns a well-structured list of findings. Input the keywords, question, or topic you want to search for using Tavily as your query. Input the maximum number of search entries you'd like to receive using maxResults - defaults to 10 if not provided.",
+      inputSchema: {
+        query: z
+          .string()
+          .min(1, "Query is required")
+          .describe("Search query string"),
+        maxResults: z
+          .number()
+          .int()
+          .min(1)
+          .max(20)
+          .optional()
+          .describe("Maximum number of results to return (default: 10)"),
+      },
+    },
+    async (args) => {
+      try {
+        const response = await tavilyClient.search(args.query, {
+          maxResults: args.maxResults ?? 10,
+        });
+
+        if (!response.results || response.results.length === 0) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: "No results were found for your search query. Please try rephrasing your search or try again in a few minutes.",
+              },
+            ],
+            isError: false,
+          };
+        }
+
+        const output: string[] = [];
+        output.push(`Found ${response.results.length} search results:\n`);
+
+        for (let i = 0; i < response.results.length; i++) {
+          const result = response.results[i];
+          output.push(`${i + 1}. ${result.title}`);
+          output.push(`   URL: ${result.url}`);
+          output.push(`   Summary: ${result.content}`);
+          output.push("");
+        }
+
+        return {
+          content: [{ type: "text", text: output.join("\n") }],
+          isError: false,
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error performing Tavily search: ${(error as Error).message}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+}
 
 server.registerTool(
   "UrlContentExtractor",


### PR DESCRIPTION
## Summary

- Added `TavilyWebSearch` MCP tool as an additive, configurable search option alongside the existing `DuckDuckGoWebSearch` tool
- Tavily tool is conditionally registered only when `TAVILY_API_KEY` is present (via smithery config object or environment variable)
- DuckDuckGo implementation remains completely untouched and always available
- Output format matches the existing DuckDuckGo tool for consistency

## Files changed

- `src/index.ts` — Import `@tavily/core`, conditionally register `TavilyWebSearch` tool when API key is available
- `package.json` — Added `@tavily/core` as a runtime dependency
- `smithery.yaml` — Declared `TAVILY_API_KEY` as an optional config/secret for Smithery-hosted deployments
- `package-lock.json` — Updated lockfile

## Dependency changes

- Added `@tavily/core` (npm)

## Environment variable changes

- Added `TAVILY_API_KEY` (optional; enables TavilyWebSearch tool when set)

## Notes for reviewers

- The Tavily tool registration is gated on key presence, so the server remains fully functional without a Tavily account
- The `config` object from `createServer` is checked first, then `process.env.TAVILY_API_KEY` as fallback
- Max results capped at 20 (Tavily API limit) vs 25 for DuckDuckGo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Automated Review

- Passed after 1 attempt(s)
- Final review: The Tavily migration is a clean, additive implementation that correctly registers a conditional TavilyWebSearch tool when TAVILY_API_KEY is provided. All tool registrations are inside createServer(), config scope is correct, the SDK is used properly, and DuckDuckGo remains untouched. Two minor issues: unrelated lockfile changes (peer flag removal on express/zod) and an always-loaded import even when the key is absent. Neither blocks approval.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional web search tool that, when configured, performs searches and returns formatted results (titles, URLs, snippets).

* **Configuration**
  * Added an optional API key setting to enable the web search feature.

* **Chores**
  * Updated dependencies to support the new web search integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->